### PR TITLE
feat: redeploy self

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: send HTTP request to deploy.altlab.dev
+      run: >-
+        curl -X POST https://deploy.altlab.dev/deploy --fail
+        -d '{ "secret": "${{ secrets.DEPLOY_ALTLAB_DEV_DEPLOY_KEY }}" }'
+        -H 'Content-Type: application/json'

--- a/app/commands.py
+++ b/app/commands.py
@@ -65,7 +65,7 @@ class RedeploySelf(Command):
         # Note: Make sure the user running this app is allowed to run this command
         # without a password. Add something like this to the sudoers file:
         #
-        #     deploy ALL=(ALL) NOPASSWD: /bin/systemd reload UNIT_NAME
+        #     deploy ALL=(ALL) NOPASSWD: /bin/systemctl reload UNIT_NAME
         #
         # See: https://toroid.org/sudoers-syntax
-        check_call(["sudo", "systemd", "reload", self.UNIT_NAME])
+        check_call(["sudo", "systemctl", "reload", self.UNIT_NAME])

--- a/app/commands.py
+++ b/app/commands.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 What to do on a deploy.
 """
@@ -45,3 +43,29 @@ class ConnectTo(Command):
 class NotConfigured(Command):
     def run(self) -> None:
         raise NotImplementedError("Deployment not configured")
+
+
+class RedeploySelf(Command):
+    """
+    How deploy.altlab.app re-deploys *itself*.
+    """
+
+    # This is how this app assumes it's configured:
+    #
+    #  - It can `git pull` itself
+    #  - It has a systemd unit file (service) that manages it.
+    #  - The unit file has ExecReload configured to gracefully reload the app.
+    #  - The user running the code can issue the systemd reload command to itself.
+
+    # systemd unit name. Check /etc/systemd/system!
+    UNIT_NAME = "deploy.altlab.dev"
+
+    def run(self) -> None:
+        check_call(["git", "pull", "--ff-only"])
+        # Note: Make sure the user running this app is allowed to run this command
+        # without a password. Add something like this to the sudoers file:
+        #
+        #     deploy ALL=(ALL) NOPASSWD: /bin/systemd reload UNIT_NAME
+        #
+        # See: https://toroid.org/sudoers-syntax
+        check_call(["sudo", "systemd", "reload", self.UNIT_NAME])

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -10,7 +10,7 @@ To add an app called {app_name}:
 
 """
 
-from .commands import ConnectTo, NotConfigured
+from .commands import ConnectTo, NotConfigured, RedeploySelf
 
 DEPLOYMENTS = {
     ############################## gunaha.altlab.app ################################
@@ -31,4 +31,6 @@ DEPLOYMENTS = {
     ),
     ############################ speech-db.altlab.app ##############################
     "speech-db": ConnectTo("speech-db@itw.altlab.dev").command("/opt/speech-db/deploy"),
+    ############################## deploy.altlab.dev ###############################
+    "deploy": RedeploySelf(),
 }

--- a/docs/application-registry.tsv
+++ b/docs/application-registry.tsv
@@ -3,3 +3,4 @@ speech-db	60004	altlab-itw:8004
 itwewina	60002	altlab-itw:8001
 gunaha	60001	altlab-itw:8000
 hello	N/A	altlab-itw:5000
+deploy	996	N/A

--- a/docs/application-registry.tsv
+++ b/docs/application-registry.tsv
@@ -3,4 +3,4 @@ speech-db	60004	altlab-itw:8004
 itwewina	60002	altlab-itw:8001
 gunaha	60001	altlab-itw:8000
 hello	N/A	altlab-itw:5000
-deploy	996	N/A
+deploy	996	altlab.dev:2020


### PR DESCRIPTION
Ironically, the deployment app did not know how to deploy itself. This PR fixes that!

I already mucked around with the config on the server to make this work; namely

 - add `ExecReload` to the systemd unit file
 - changed to the sudoer file to allow the `deploy` user to run the command `sudo systemctl reload deploy.altlab.dev` and ONLY that command!
 - changed the owner/group of the containing directory to `deploy:deploy`
 - added a secret key for `deploy`