### PR TITLE
Bump deploy timeout to match nginx config

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -7,4 +7,4 @@ bind = "127.0.0.1:2020"
 #  - collecting and post-processing static assets
 #  - etc.
 # So wait a long time before giving up!
-timeout = 240
+timeout = 600


### PR DESCRIPTION
The error in the nginx log on deploy is:

    [error] upstream prematurely closed connection while reading response header from upstream