### PR TITLE
Point itwêwina deploy at kor.altlab.dev

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -19,8 +19,8 @@ DEPLOYMENTS = {
     ############################### hello.altlab.dev ###############################
     "hello": ConnectTo("itw.altlab.dev").command("/opt/hello.altlab.dev/deploy"),
     ############################# itwewina.altlab.app ##############################
-    "itwewina": ConnectTo("itwewina@itw.altlab.dev").command(
-        "/opt/docker-compose/itwewina/cree-intelligent-dictionary/docker/deploy"
+    "itwewina": ConnectTo("itwewina@kor.altlab.dev").command(
+        "/home/itwewina/cree-intelligent-dictionary/docker/deploy"
     ),
     ##################################### Korp #####################################
     "korp-frontend-dev": ConnectTo("kor.altlab.dev").command(

--- a/docs/application-registry.tsv
+++ b/docs/application-registry.tsv
@@ -1,7 +1,7 @@
 Application	UID/GID	Listening on...	Notes
 speech-db	60004	altlab-itw:8004	
-itwewina	60002	altlab-itw:8001	
-itwewina	60002	altlab-itw:9191	uwsgi stats monitor; use uwsgitop to inspect the live server!
+itwewina	60002	altlab-kor:8001	
+itwewina	60002	altlab-kor:9191	uwsgi stats monitor; use uwsgitop to inspect the live server!
 gunaha	60001	altlab-itw:8000	
 hello	N/A	altlab-itw:5000	
 deploy	996	altlab-gw:2020	Port bound to 127.0.0.1 ONLY!


### PR DESCRIPTION
The service has been moved there temporarily for maintenance on
itw.altlab.dev. Note that the data is stored in `/home/itwewina`, not
`/etc` or `/opt`, because docker is installed via snapd on kor, causing it
to acquire an apparmor policy that denies writes to `/etc` or `/opt`.