### PR TITLE
Move speech-db back to itw

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -30,7 +30,7 @@ DEPLOYMENTS = {
         "/etc/docker/compose/korp-prod/deploy"
     ),
     ############################ speech-db.altlab.app ##############################
-    "speech-db": ConnectTo("speech-db@kor.altlab.dev").command("/home/speech-db/recording-validation-interface/deploy"),
+    "speech-db": ConnectTo("speech-db@itw.altlab.dev").command("/opt/speech-db/deploy"),
     ############################## deploy.altlab.dev ###############################
     "deploy": RedeploySelf(),
 }

--- a/docs/application-registry.tsv
+++ b/docs/application-registry.tsv
@@ -1,5 +1,5 @@
 Application	UID/GID	Listening on...	Notes
-speech-db	60004	altlab-kor:8004	
+speech-db	60004	altlab-itw:8004	
 itwewina	60002	altlab-kor:8001	
 itwewina	60002	altlab-kor:9191	uwsgi stats monitor; use uwsgitop to inspect the live server!
 gunaha	60001	altlab-itw:8000	


### PR DESCRIPTION
This reverts commit 00c456f6fcc0f637ff5f3f779c7d2c2efd5105c1.

FYI, to make speech-db actually run on altlab-kor, I had manually applied the following patch in `/home/speech-db/recording-validation-interface`:

```
diff --git a/docker-compose.yml b/docker-compose.yml
index 6a2d741..9b08817 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,6 @@ services:
         volumes:
         # HOST : CONTAINER
         - "./.env:/app/.env"
-        - "/data/application-data/speech-db/db.sqlite3:/app/db.sqlite3"
-        - "/data/application-data/speech-db/audio:/app/data/audio"
\ No newline at end of file
+        - "/var/lib/snapd/hostfs/data/application-data/speech-db/db.sqlite3:/app/db.sqlite3"
+        - "/var/lib/snapd/hostfs/data/application-data/speech-db/crk.zhfst:/app/crk.zhfst"
+        - "/var/lib/snapd/hostfs/data/application-data/speech-db/audio:/app/data/audio"
```