### PR TITLE
add: configuration for speech-db-dev

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -28,6 +28,8 @@ DEPLOYMENTS = {
     ),
     # speech-db.altlab.app
     "speech-db": ConnectTo("speech-db@itw.altlab.dev").command("/opt/speech-db/deploy"),
+    # speech-db.altlab.dev
+    "speech-db-dev": ConnectTo("speech-db@itw.altlab.dev").command("/opt/speech-db-dev/deploy"),
     # deploy.altlab.dev
     "deploy": RedeploySelf(),
 }


### PR DESCRIPTION
This is one of my steps on the path to creating a `speech-db.altlab.dev` site for internal testing before releasing a rather large change.